### PR TITLE
:construction: Set up basic logout funcitionality

### DIFF
--- a/backend/src/pikoshi/migrations/versions/25b556f883b8_added_users_table.py
+++ b/backend/src/pikoshi/migrations/versions/25b556f883b8_added_users_table.py
@@ -29,7 +29,7 @@ def upgrade() -> None:
         sa.Column("password", sa.String(length=254), nullable=False, index=True),
         sa.Column("salt", sa.String(64), unique=True, nullable=False, index=True),
         sa.Column("email", sa.Text, unique=True, index=True),
-        sa.Column("is_active", sa.Boolean(), default=True),
+        sa.Column("is_active", sa.Boolean(), default=False),
         sa.Column("last_login", sa.DateTime(timezone=True)),
     )
 

--- a/backend/src/pikoshi/models/user.py
+++ b/backend/src/pikoshi/models/user.py
@@ -13,7 +13,7 @@ class User(Base):
     password = Column(String(254), nullable=False, index=True)
     salt = Column(String(64), unique=True, nullable=False, index=True)
     email = Column(Text, unique=True, index=True)
-    is_active = Column(Boolean, nullable=True, default=True)
+    is_active = Column(Boolean, nullable=True, default=False)
     last_login = Column(DateTime(timezone=True), onupdate=func.now())
 
     def __repr__(self):

--- a/backend/src/pikoshi/routers/auth_context.py
+++ b/backend/src/pikoshi/routers/auth_context.py
@@ -43,3 +43,15 @@ async def check_auth_context(
         return ExceptionService.handle_value_exception(ve)
     except Exception as e:
         return ExceptionService.handle_generic_exception(e)
+
+
+@router.post("/auth-logout/")
+async def auth_logout(
+    access_token: Annotated[str | None, Cookie()] = None,
+    db: Session = Depends(get_db),
+) -> Response:
+    try:
+        response = await AuthService.logout(str(access_token), db)
+        return response
+    except Exception as e:
+        return ExceptionService.handle_generic_exception(e)

--- a/backend/src/pikoshi/services/google_oauth_service.py
+++ b/backend/src/pikoshi/services/google_oauth_service.py
@@ -16,6 +16,7 @@ from ..services.user_service import (
     generate_user_profile,
     get_user_by_email,
     set_user_as_active,
+    update_user_last_login,
 )
 
 load_dotenv()
@@ -107,6 +108,7 @@ class GoogleOAuthService:
             f"auth_session_{access_token}", new_user.id, ex=3600  # type:ignore
         )
         set_user_as_active(db, new_user)
+        update_user_last_login(db, new_user)
 
     @staticmethod
     async def authenticate_user_with_google(
@@ -137,3 +139,4 @@ class GoogleOAuthService:
         user_id = user_from_db.id
         await redis.set(f"auth_session_{access_token}", user_id, ex=3600)  # type:ignore
         set_user_as_active(db, user_from_db)
+        update_user_last_login(db, user_from_db)

--- a/backend/src/pikoshi/services/jwt_service.py
+++ b/backend/src/pikoshi/services/jwt_service.py
@@ -16,6 +16,7 @@ from ..services.user_service import (
     generate_user_profile,
     get_user_by_email,
     set_user_as_active,
+    update_user_last_login,
 )
 
 load_dotenv()
@@ -93,6 +94,7 @@ class JWTAuthService:
             f"auth_session_{access_token}", user_id, ex=3600  # type:ignore
         )
         set_user_as_active(db, user_from_db)
+        update_user_last_login(db, user_from_db)
 
     @staticmethod
     async def authenticate_user_with_jwt(
@@ -132,3 +134,4 @@ class JWTAuthService:
             f"auth_session_{access_token}", user_id, ex=3600  # type:ignore
         )
         set_user_as_active(db, user_from_db)
+        update_user_last_login(db, user_from_db)

--- a/backend/src/pikoshi/services/user_service.py
+++ b/backend/src/pikoshi/services/user_service.py
@@ -50,3 +50,9 @@ def set_user_as_active(db: Session, user: User) -> None:
     user.__setattr__("is_active", True)
     db.add(user)
     db.commit()
+
+
+def update_user_last_login(db: Session, user: User) -> None:
+    user.__setattr__("last_login", func.now())
+    db.add(user)
+    db.commit()

--- a/backend/src/pikoshi/services/user_service.py
+++ b/backend/src/pikoshi/services/user_service.py
@@ -56,3 +56,9 @@ def update_user_last_login(db: Session, user: User) -> None:
     user.__setattr__("last_login", func.now())
     db.add(user)
     db.commit()
+
+
+def set_user_as_inactive(db: Session, user: User) -> None:
+    user.__setattr__("is_active", False)
+    db.add(user)
+    db.commit()

--- a/backend/src/pikoshi/utils/auth_cookies.py
+++ b/backend/src/pikoshi/utils/auth_cookies.py
@@ -26,3 +26,9 @@ def set_auth_cookies(
     response = set_auth_cookie(response, "access_token", access_token, 3600)
     response = set_auth_cookie(response, "refresh_token", refresh_token, 86400)
     return response
+
+
+def remove_auth_cookies(response: Response) -> Response:
+    response.delete_cookie(key="access_token")
+    response.delete_cookie(key="refresh_token")
+    return response

--- a/frontend/src/components/LogoutBtn.tsx
+++ b/frontend/src/components/LogoutBtn.tsx
@@ -1,0 +1,32 @@
+import { type Component } from 'solid-js';
+import { useNavigate } from '@solidjs/router';
+
+import urls from '../config/urls';
+
+import { delay } from '../utils/utils';
+
+const LogoutBtn: Component = () => {
+    const navigate = useNavigate();
+    const logout = async () => {
+        try {
+            const response = await fetch(urls.BACKEND_AUTH_LOGOUT_ROUTE, {
+                method: 'POST',
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                },
+                credentials: 'include',
+            });
+            const jsonRes = await response.json();
+            if (!response.ok) throw new Error(jsonRes.message);
+            await delay(3000);
+            navigate('/');
+        } catch (err) {
+            const error = err as Error;
+            console.error('ERROR :=>', error);
+        }
+    };
+    return <button onClick={logout}>Logout</button>;
+};
+
+export default LogoutBtn;

--- a/frontend/src/config/urls.ts
+++ b/frontend/src/config/urls.ts
@@ -7,4 +7,5 @@ export default {
         'http://localhost:8000/auth/email-onboarding/',
     BACKEND_EMAIL_LOGIN_ROUTE: 'http://localhost:8000/auth/email-login/',
     BACKEND_AUTH_CONTEXT_ROUTE: 'http://localhost:8000/auth/auth-context/',
+    BACKEND_AUTH_LOGOUT_ROUTE: 'http://localhost:8000/auth/auth-logout/',
 };

--- a/frontend/src/views/Gallery.tsx
+++ b/frontend/src/views/Gallery.tsx
@@ -1,22 +1,21 @@
 import { createSignal, onMount, Show, type Component } from 'solid-js';
 import { useNavigate } from '@solidjs/router';
+import LogoutBtn from '../components/LogoutBtn';
 
 import urls from '../config/urls';
 
-import { delay, grabStoredCookie } from '../utils/utils';
+import { delay } from '../utils/utils';
 
 const Gallery: Component = () => {
     const [isAuthenticated, setIsAuthenticated] = createSignal(false);
     const navigate = useNavigate();
     onMount(async () => {
         try {
-            // const csrfToken = grabStoredCookie('csrftoken');
             const response = await fetch(urls.BACKEND_AUTH_CONTEXT_ROUTE, {
                 method: 'POST',
                 headers: {
                     Accept: 'application/json',
                     'Content-Type': 'application/json',
-                    // 'X-CSRFToken': csrfToken,
                 },
                 credentials: 'include',
             });
@@ -35,6 +34,7 @@ const Gallery: Component = () => {
         <>
             <Show when={isAuthenticated()} fallback={<p>Loading...</p>}>
                 <h1>Gallery</h1>
+                <LogoutBtn />
             </Show>
         </>
     );


### PR DESCRIPTION
This PR brings in the initial Logout authentication logic. Establishing logout as simply clearing the redis cache, setting the is_active flag in the DB to false, and removing the authentication cookies from the client.

Note that the front end logic for this might need to be refactored depending on how we wish to display confirmation of successful/unsuccessful logout to the user.