### PR TITLE
:WIP: 026_integrate_intersection_observer

### DIFF
--- a/frontend/src/views/Gallery.tsx
+++ b/frontend/src/views/Gallery.tsx
@@ -66,7 +66,6 @@ const Gallery: Component = () => {
 
     const abortController = new AbortController();
 
-    // TODO: Wrap in try/catch/throws
     onMount(async () => {
         const authContext = await useAuthContext();
         setIsAuthenticated(authContext);
@@ -140,11 +139,30 @@ const Gallery: Component = () => {
             observerOptions,
         );
 
+        /* NOTE: TS warninig ignored: imagesLoaded() check above
+         * ensures observerRef() is defined here */
         if (observerRef) observer.observe(observerRef()!);
 
         onCleanup(() => {
             if (observerRef) observer.unobserve(observerRef()!);
         });
+    });
+
+    createEffect(() => {
+        /*
+         * Opens Dialogue Box letting user know that data may not be
+         * saved, i.e. prevents user from navigating away/refreshing while
+         * images are still streaming in.
+         */
+        const handleBeforeUnload = (event: Event) => {
+            if (!imagesLoaded()) {
+                event.preventDefault();
+            }
+        };
+        window.addEventListener("beforeunload", handleBeforeUnload);
+        onCleanup(() =>
+            window.removeEventListener("beforeunload", handleBeforeUnload),
+        );
     });
 
     const handleScroll = () => {

--- a/frontend/src/views/Gallery.tsx
+++ b/frontend/src/views/Gallery.tsx
@@ -119,7 +119,7 @@ const Gallery: Component = () => {
     });
 
     createEffect(() => {
-        if (!imagesLoaded()) return;
+        if (!imagesLoaded() || !isScrollingDown()) return;
 
         const observerOptions = {
             root: null,
@@ -129,7 +129,7 @@ const Gallery: Component = () => {
 
         const observerCallBack = (entries: IntersectionObserverEntry[]) => {
             entries.forEach(entry => {
-                if (entry.isIntersecting && isScrollingDown()) {
+                if (entry.isIntersecting) {
                     handleLoadMore();
                 }
             });

--- a/frontend/src/views/Gallery.tsx
+++ b/frontend/src/views/Gallery.tsx
@@ -113,6 +113,7 @@ const Gallery: Component = () => {
         openImageModal(image);
     };
 
+    // TODO: Hook Up Intersection Observer/Infinite Scroll Logic Here
     const handleLoadMore = async () => {
         try {
             const imageCount = await useGrabImageCount();


### PR DESCRIPTION
# Ticket No: 026

This ticket integrates the use of the
[Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
in a classic "Infinite Scroll" feature common to many image sharing/social media
platforms.

## User Story

As A User I want to be able to scroll through my Gallery Images and have them
dynamically load as I scroll, creating the illusion that all my images are
loaded. This should create a seamless experience where ideally I should not see
any loading indicators whatsoever (or if I do, they are shown only briefly
before the next set of my images load).

**TODO:**

- [ ] Become familiar with the
      [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
      and simply get the scroll event to be hooked up to it (test via
      console.logs).
- [ ] Utilize tutorials and articles to further familiarize yourself with common
      techniques used to create an infinite scroll of gallery images.

- [ ] Once familiar, set up the Intersection Observer Implementation in
      `views/Gallery.tsx` file, replacing the "Load More Images" button with
      this Intersection Observer implementation.
- [ ] Optimize the pagination/streaming strategy to see if you can get the
      timing of the image loading to be seamless, meaning the user is only aware
      of the images loading if they scroll quickly to the bottom of the page,
      but if they scroll slowly/regular pace, they may never see the loading
      spinners.
